### PR TITLE
Anisotropic Downsampling & Dask configs

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -9,6 +9,7 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.9.0-h0fbd49f_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.9.2-he7b75e1_1.conda
@@ -138,6 +139,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-21.0.0-py311h38be061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-21.0.0-py311h342b5a4_0_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.33.2-py311hdae7d1d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pytest-8.4.1-pyhd8ed1ab_0.conda
@@ -159,6 +162,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tomli-2.2.1-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/toolz-1.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tornado-6.5.2-py311h49ec1c0_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.1-h4440ef1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025b-h78e105d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.5.0-pyhd8ed1ab_0.conda
@@ -198,6 +203,18 @@ packages:
   purls: []
   size: 23621
   timestamp: 1650670423406
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
+  sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
+  md5: 2934f256a8acfe48f6ebb4fce6cde29c
+  depends:
+  - python >=3.9
+  - typing-extensions >=4.0.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/annotated-types?source=hash-mapping
+  size: 18074
+  timestamp: 1733247158254
 - conda: https://conda.anaconda.org/conda-forge/noarch/asciitree-0.3.3-py_2.tar.bz2
   sha256: b3e9369529fe7d721b66f18680ff4b561e20dbf6507e209e1f60eac277c97560
   md5: c0481c9de49f040272556e2cedf42816
@@ -2061,6 +2078,39 @@ packages:
   - pkg:pypi/pycparser?source=hash-mapping
   size: 110100
   timestamp: 1733195786147
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.11.7-pyh3cfb1c2_0.conda
+  sha256: ee7823e8bc227f804307169870905ce062531d36c1dcf3d431acd65c6e0bd674
+  md5: 1b337e3d378cde62889bb735c024b7a2
+  depends:
+  - annotated-types >=0.6.0
+  - pydantic-core 2.33.2
+  - python >=3.9
+  - typing-extensions >=4.6.1
+  - typing-inspection >=0.4.0
+  - typing_extensions >=4.12.2
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic?source=hash-mapping
+  size: 307333
+  timestamp: 1749927245525
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.33.2-py311hdae7d1d_0.conda
+  sha256: b48e5abb6debae4f559b08cdbaf0736c7806adc00c106ced2c98a622b7081d8f
+  md5: 484d0d62d4b069d5372680309fc5f00c
+  depends:
+  - python
+  - typing-extensions >=4.6.0,!=4.7.0
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/pydantic-core?source=hash-mapping
+  size: 1898139
+  timestamp: 1746625319478
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
   sha256: 5577623b9f6685ece2697c6eb7511b4c9ac5fb607c9babc2646c811b428fd46a
   md5: 6b6ece66ebcae2d5f326c77ef2c5a066
@@ -2344,6 +2394,28 @@ packages:
   - pkg:pypi/tornado?source=hash-mapping
   size: 869655
   timestamp: 1754732128935
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-extensions-4.14.1-h4440ef1_0.conda
+  sha256: 349951278fa8d0860ec6b61fcdc1e6f604e6fce74fabf73af2e39a37979d0223
+  md5: 75be1a943e0a7f99fcf118309092c635
+  depends:
+  - typing_extensions ==4.14.1 pyhe01879c_0
+  license: PSF-2.0
+  license_family: PSF
+  purls: []
+  size: 90486
+  timestamp: 1751643513473
+- conda: https://conda.anaconda.org/conda-forge/noarch/typing-inspection-0.4.1-pyhd8ed1ab_0.conda
+  sha256: 4259a7502aea516c762ca8f3b8291b0d4114e094bdb3baae3171ccc0900e722f
+  md5: e0c3cd765dc15751ee2f0b03cd015712
+  depends:
+  - python >=3.9
+  - typing_extensions >=4.12.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/typing-inspection?source=hash-mapping
+  size: 18809
+  timestamp: 1747870776989
 - conda: https://conda.anaconda.org/conda-forge/noarch/typing_extensions-4.14.1-pyhe01879c_0.conda
   sha256: 4f52390e331ea8b9019b87effaebc4f80c6466d09f68453f52d5cdc2a3e1194f
   md5: e523f4f1e980ed7a4240d7e27e9ec81f

--- a/pixi.toml
+++ b/pixi.toml
@@ -17,6 +17,7 @@ numcodecs = ">=0.15.1,<0.16.1"
 click = ">=8.1.8,<9.0.0"
 scipy = ">=1.16.1"
 pytest = "*"
+pydantic = ">=2.11.7,<3"
 
 [pypi-dependencies]
 xarray-multiscale = ">=2.1.0"

--- a/src/dask_utils.py
+++ b/src/dask_utils.py
@@ -3,9 +3,11 @@ from dask.distributed import Client, LocalCluster
 import os
 import sys
 import logging
+from typing import List
 
-
-def initialize_dask_client(cluster_type: str | None = None, log_dir: str = None) -> Client:
+def initialize_dask_client(cluster_type: str | None = None,
+                           log_dir: str = None,
+                           job_extra_directives = List[str]) -> Client:
     """Initialize dask client.
 
     Args:
@@ -27,6 +29,7 @@ def initialize_dask_client(cluster_type: str | None = None, log_dir: str = None)
             walltime="48:00",
             log_directory = log_dir,
             local_directory="/scratch/$USER/",
+            job_extra_directives = job_extra_directives
         )
     elif cluster_type == "local":
         cluster = LocalCluster()

--- a/src/downsampling.py
+++ b/src/downsampling.py
@@ -1,0 +1,104 @@
+from typing import Tuple
+from xarray_multiscale import windowed_mean, windowed_mode
+#from xarray_multiscale.reducers import windowed_mode_countless, windowed_mode_scipy
+import zarr
+import scipy.ndimage as ndi
+
+def upscale_slice(slc: slice, factor: int):
+    """
+    Returns input slice coordinates. 
+
+    Args:
+        slc : output slice
+        factor : upsampling factor
+    Returns:
+        slice: source array slice
+    """
+    return slice(slc.start * factor, slc.stop * factor, slc.step)
+
+def downsample_save_chunk_mode(
+        source: zarr.Array, 
+        dest: zarr.Array, 
+        out_slices: Tuple[slice, ...],
+        downsampling_factors: Tuple[int, ...],
+        data_origin: str,
+        antialiasing : bool):
+    
+    """
+    Downsamples source array slice and writes into destination array. 
+
+    Args:
+        source : source zarr array that needs to be downsampled
+        dest : destination zarr array that contains downsampled data
+        out_slices : part of the destination array that would contain the output data
+        downsampling_factors : tuple that contains downsampling factors. dim(downsampling_factors) must match the shape of the source array
+        data_origin : affects which downsampling method is used. Accepts two values: segmentation or raw
+    """
+    
+    in_slices = tuple(upscale_slice(out_slice, fact) for out_slice, fact in zip(out_slices, downsampling_factors))
+    source_data = source[in_slices]
+    # only downsample source_data if it is not all 0s
+    if not (source_data == 0).all():
+        if data_origin == 'segmentations':
+            ds_data = windowed_mode(source_data, window_size=downsampling_factors)
+        elif data_origin == 'raw':
+            if antialiasing:
+                # blur data in chunk before downsampling to reduce aliasing of the image 
+                # conservative Gaussian blur coeff: 2/2.5 = 0.8
+                sigma = [0 if factor == 1 else factor/2.5 for factor in downsampling_factors]
+                filtered_data = ndi.gaussian_filter(source_data, sigma=sigma)
+                ds_data = windowed_mean(filtered_data, window_size=downsampling_factors)
+            else:
+                ds_data = windowed_mean(source_data, window_size=downsampling_factors)
+
+        dest[out_slices] = ds_data
+    return 0
+
+def get_downsampling_factors(shape, axes_order, min_ratio=0.5, max_ratio=2.0, high_aspect_ratio=False):
+    """
+    Calculate adaptive downsampling factors based on aspect ratios.
+    
+    Args:
+        shape: Array shape (c, z, y, x)
+        axes_order: List of axis names ['c', 'z', 'y', 'x']
+        min_ratio: Minimum allowed ratio (default 0.5)
+        max_ratio: Maximum allowed ratio (default 2.0)
+    
+    Returns:
+        List of downsampling factors
+    """
+    if high_aspect_ratio==False:
+        return [ 1 if axis in ['c', 't'] else 2 for axis in axes_order]
+    else:
+        # Get spatial dimensions (skip channel and time)
+        spatial_dims = list((axis, shape[i]) for i, axis in enumerate(axes_order) if axis not in ['c', 't'])
+        
+        axes, dimensions = zip(*spatial_dims)
+    
+        if len(dimensions) == 1:
+            factors = [2]
+        else:
+            ratios = []
+            for i, dim in enumerate(dimensions):
+                # Calculate ratios of current dimension to all others
+                # for example for 3D:  [(z/y, z/x),(y/z, y/x),(x/z, x/y)]
+                dim_ratios = tuple(dim / dimensions[j] for j in range(len(dimensions)) if j != i)
+                ratios.append(dim_ratios)
+            
+            # Determine downsampling factors for each spatial dimension
+            factors = []
+            for (i,dim_ratios) in enumerate(ratios):
+                # Check if both ratios are within acceptable range
+                if all(ratio >= max_ratio for ratio in dim_ratios):
+                    factors = [1,]*len(ratios)
+                    factors[i] = 2
+                    break
+                elif all(ratio <= min_ratio for ratio in dim_ratios):
+                    factors = [2,]*len(ratios)
+                    factors[i] = 1
+                    break
+                else:
+                    factors.append(2)
+        
+        spatial_factors = {k : v for k,v in zip(axes, factors)}
+        return tuple(1 if axis in ['c', 't'] else spatial_factors[axis] for axis in axes_order)

--- a/src/pydantic_models.py
+++ b/src/pydantic_models.py
@@ -1,0 +1,71 @@
+from pydantic import BaseModel, validator, model_validator
+from typing import Optional, Literal, List
+import math
+import zarr
+import click
+import yaml
+
+class Config(BaseModel):
+    src: str
+    workers: int = 100
+    data_origin: Literal['raw', 'segmentations']
+    cluster: Optional[str] = None
+    log_dir: Optional[str] = None
+    antialiasing: bool = False
+    high_aspect_ratio: bool = False
+    custom_scale_factors:  Optional[List[List[float]]] = None
+    
+    @validator('src')
+    def src_must_exist(cls, v):
+        import os
+        if not os.path.exists(v):
+            raise ValueError(f'Source path {v} does not exist')
+        return v
+    
+    @validator('workers')
+    def workers_positive(cls, v):
+        if v <= 0:
+            raise ValueError('Workers must be positive')
+        return v
+    
+    @model_validator(mode="before")
+    def check_dimensions(cls, values):
+        src = values.get('src')
+        scale_factors = values.get('custom_scale_factors')
+        z_root = zarr.open(src)
+        
+        try:
+            s0 = z_root['s0']
+        except:
+            raise ValueError(f"No s0 array found in {src}")
+        
+        s0_shape = s0.shape
+        
+        for window in scale_factors:
+            if len(window) != len(s0_shape):
+                raise ValueError(f'number of dimensions of the window and array shape must match')
+         
+        # check that each scale is a factor of 2:
+        if not all([x > 0 and abs(math.log2(x) - round(math.log2(x))) < 1e-10 for xs in scale_factors for x in xs]):
+            raise ValueError(f'Some of the factors are not a power of 2.')
+        
+        if any([int(s0_dim/ sc) > 32 for s0_dim, sc in zip(s0_shape, scale_factors[-1])]):
+            raise ValueError('not enough custom scale levels to generate full multiscale pyramid')
+
+        return values
+    
+def validate_config(config, **kwargs):
+        with open(config, 'r') as f:
+            config_data = yaml.safe_load(f)
+        
+        # Override config with CLI arguments (CLI takes precedence)
+        for key, value in kwargs.items():
+            if value is not None:  # Only override if CLI arg was provided
+                config_data[key] = value
+        
+        # Validate config
+        try:
+            return Config(**config_data).dict()
+        except Exception as e:
+            click.echo(f"Configuration validation error: {e}", err=True)
+            raise click.Abort()

--- a/src/pydantic_models.py
+++ b/src/pydantic_models.py
@@ -31,7 +31,7 @@ class Config(BaseModel):
     @model_validator(mode="before")
     def check_dimensions(cls, values):
         src = values.get('src')
-        scale_factors = values.get('custom_scale_factors')
+        scale_factors = values.get('custom_scale_factors', None)
         z_root = zarr.open(src)
         
         try:
@@ -41,16 +41,17 @@ class Config(BaseModel):
         
         s0_shape = s0.shape
         
-        for window in scale_factors:
-            if len(window) != len(s0_shape):
-                raise ValueError(f'number of dimensions of the window and array shape must match')
-         
-        # check that each scale is a factor of 2:
-        if not all([x > 0 and abs(math.log2(x) - round(math.log2(x))) < 1e-10 for xs in scale_factors for x in xs]):
-            raise ValueError(f'Some of the factors are not a power of 2.')
-        
-        if any([int(s0_dim/ sc) > 32 for s0_dim, sc in zip(s0_shape, scale_factors[-1])]):
-            raise ValueError('not enough custom scale levels to generate full multiscale pyramid')
+        if scale_factors:
+            for window in scale_factors:
+                if len(window) != len(s0_shape):
+                    raise ValueError(f'number of dimensions of the window and array shape must match')
+            
+            # check that each scale is a factor of 2:
+            if not all([x > 0 and abs(math.log2(x) - round(math.log2(x))) < 1e-10 for xs in scale_factors for x in xs]):
+                raise ValueError(f'Some of the factors are not a power of 2.')
+            
+            if any([int(s0_dim/ sc) > 32 for s0_dim, sc in zip(s0_shape, scale_factors[-1])]):
+                raise ValueError('not enough custom scale levels to generate full multiscale pyramid')
 
         return values
     

--- a/src/pydantic_models.py
+++ b/src/pydantic_models.py
@@ -14,6 +14,7 @@ class Config(BaseModel):
     antialiasing: bool = False
     high_aspect_ratio: bool = False
     custom_scale_factors:  Optional[List[List[float]]] = None
+    project_name: str = None
     
     @validator('src')
     def src_must_exist(cls, v):

--- a/src/to_multiscale.py
+++ b/src/to_multiscale.py
@@ -77,7 +77,7 @@ def get_downsampling_factors(shape, axes_order, min_ratio=0.5, max_ratio=2.0, hi
         List of downsampling factors
     """
     if high_aspect_ratio==False:
-        return [ 1 if axis in ['c', 't'] else 2 for axis in axes_order]
+        return tuple( 1 if axis in ['c', 't'] else 2 for axis in axes_order)
     else:
         # Get spatial dimensions (skip channel and time)
         spatial_dims = list((axis, shape[i]) for i, axis in enumerate(axes_order) if axis not in ['c', 't'])

--- a/src/to_multiscale.py
+++ b/src/to_multiscale.py
@@ -139,7 +139,7 @@ def create_multiscale(z_root: zarr.Group,
     spatial_shape = list(source_shape[i] for i, axis in enumerate(axes_order) if axis not in ['c', 't'])
     
     #continue downsampling if output array dimensions > 32 
-    while all([dim > 32 for dim in spatial_shape]):
+    while all([dim > 16 for dim in spatial_shape]):
         print(f'{level=}')
         source_arr = z_root[f's{level-1}']
         
@@ -215,6 +215,7 @@ def create_multiscale(z_root: zarr.Group,
     help="The path of the parent directory for all LSF worker logs.  Omit if you want worker logs to be emailed to you.")
 @click.option('--antialiasing', '-aa', type=click.BOOL, help='Reduce aliasing of the image by blurring it with Gaussian filter before downsampling. Default: False')
 @click.option('--high_aspect_ratio', '--har', type=click.BOOL, help='Reduce aspect ratio of the data array more and more with each downsampling level. Metadata in zattrs is being recomputed accordingly. Default: False.')
+@click.option('--project_name', '-p', type=click.STRING, help='specify project name when running on an LSF cluster.')
 def cli(config, **kwargs):
     
     if config:
@@ -222,11 +223,12 @@ def cli(config, **kwargs):
     else:
         config_dict = {k: v for k, v in kwargs.items() if v is not None}
     
-    src_store = zarr.NestedDirectoryStore(config_dict['src'])
-    src_root = zarr.open_group(store=src_store, mode = 'a')
+    #src_store = zarr.NestedDirectoryStore(config_dict['src'])
+    src_root = zarr.open_group(config_dict['src'], mode = 'a')
 
     client = initialize_dask_client(cluster_type=config_dict['cluster'],
-                                    log_dir=config_dict.get('log_dir', None))
+                                    log_dir=config_dict.get('log_dir', None),
+                                    job_extra_directives=[f'-P {config_dict["project_name"]}'])
     client.cluster.scale(int(config_dict['workers']))
     create_multiscale(z_root=src_root,
                       client=client,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ def temp_zarr_array():
     temp_dir = tempfile.mkdtemp()
     
     # Create a simple 4D test array (C, Z, Y, X)
-    test_data = np.random.randint(0, 255, size=(2, 64, 128, 128), dtype=np.uint8)
+    test_data = np.random.randint(0, 255, size=(2, 63, 128, 128), dtype=np.uint8)
     
     store = zarr.DirectoryStore(temp_dir)
     root = zarr.group(store=store)

--- a/tests/test_to_multiscale.py
+++ b/tests/test_to_multiscale.py
@@ -2,6 +2,7 @@ import pytest
 from unittest.mock import patch
 import sys
 import os
+import numpy as np
 
 # Add src to path for imports
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
@@ -11,6 +12,7 @@ from to_multiscale import (
     upscale_slice, 
     downsample_save_chunk_mode,
     create_multiscale,
+    get_downsampling_factors
 )
 
 
@@ -42,9 +44,13 @@ class TestDownsampleSaveChunkMode:
         """Test downsampling segmentation data."""
         z_root, temp_dir = temp_zarr_array
         source_arr = z_root['s0']
+        axes_order = [axis['name'].lower() for axis in z_root.attrs['multiscales'][0]['axes']]
+
+        # Get downsampling factors first
+        downsampling_factors = tuple(get_downsampling_factors(source_arr.shape, axes_order, high_aspect_ratio=True))
         
-        # Create destination array
-        dest_shape = [dim // 2 for dim in source_arr.shape]
+        # Create destination array with proper shape calculation
+        dest_shape = [dim // factor for dim, factor in zip(source_arr.shape, downsampling_factors)]
         dest_arr = z_root.create_dataset(
             's1',
             shape=dest_shape,
@@ -52,23 +58,26 @@ class TestDownsampleSaveChunkMode:
             dtype=source_arr.dtype
         )
         
-        out_slices = (slice(0, 1), slice(0, 32), slice(0, 64), slice(0, 64))
-        downsampling_factors = (1, 2, 2, 2)
-        
+        # Use output slices that match the actual destination shape
+        out_slices = (slice(0, 1), slice(0, dest_shape[1]), slice(0, dest_shape[2]), slice(0, dest_shape[3]))
         result = downsample_save_chunk_mode(
             source_arr, dest_arr, out_slices, 
             downsampling_factors, 'segmentations', False
         )
         
         assert result == 0
-        assert dest_arr[out_slices].shape == (1, 32, 64, 64)
+        assert dest_arr[out_slices].shape == (1, dest_shape[1], dest_shape[2], dest_shape[3])
     
     def test_downsample_raw_no_antialiasing(self, temp_zarr_array):
         """Test downsampling raw data without antialiasing."""
         z_root, temp_dir = temp_zarr_array
         source_arr = z_root['s0']
+        axes_order = [axis['name'].lower() for axis in z_root.attrs['multiscales'][0]['axes']]
         
-        dest_shape = [dim // 2 for dim in source_arr.shape]
+        # Get downsampling factors that work with the actual array shape
+        downsampling_factors = get_downsampling_factors(source_arr.shape, axes_order, high_aspect_ratio=True)
+        
+        dest_shape = [dim // factor for dim, factor in zip(source_arr.shape, downsampling_factors)]
         dest_arr = z_root.create_dataset(
             's1',
             shape=dest_shape,
@@ -76,8 +85,7 @@ class TestDownsampleSaveChunkMode:
             dtype=source_arr.dtype
         )
         
-        out_slices = (slice(0, 1), slice(0, 32), slice(0, 64), slice(0, 64))
-        downsampling_factors = (1, 2, 2, 2)
+        out_slices = (slice(0, 1), slice(0, dest_shape[1]), slice(0, dest_shape[2]), slice(0, dest_shape[3]))
         
         result = downsample_save_chunk_mode(
             source_arr, dest_arr, out_slices,
@@ -91,8 +99,12 @@ class TestDownsampleSaveChunkMode:
         """Test downsampling raw data with antialiasing."""
         z_root, temp_dir = temp_zarr_array
         source_arr = z_root['s0']
+        axes_order = [axis['name'].lower() for axis in z_root.attrs['multiscales'][0]['axes']]
         
-        dest_shape = [dim // 2 for dim in source_arr.shape]
+        # Get downsampling factors that work with the actual array shape
+        downsampling_factors = get_downsampling_factors(source_arr.shape, axes_order, high_aspect_ratio=True)
+        
+        dest_shape = [dim // factor for dim, factor in zip(source_arr.shape, downsampling_factors)]
         dest_arr = z_root.create_dataset(
             's1',
             shape=dest_shape,
@@ -100,11 +112,16 @@ class TestDownsampleSaveChunkMode:
             dtype=source_arr.dtype
         )
         
-        # Mock the gaussian filter to return the same data
-        mock_filter.return_value = source_arr[0:1, 0:64, 0:128, 0:128]
+        # Mock the gaussian filter to return properly sized data
+        expected_in_shape = tuple(
+            slice_obj.stop - slice_obj.start if isinstance(slice_obj, slice) else 1
+            for slice_obj in (slice(0, 1), slice(0, dest_shape[1] * downsampling_factors[1]), 
+                             slice(0, dest_shape[2] * downsampling_factors[2]), 
+                             slice(0, dest_shape[3] * downsampling_factors[3]))
+        )
+        mock_filter.return_value = np.zeros(expected_in_shape, dtype=source_arr.dtype)
         
-        out_slices = (slice(0, 1), slice(0, 32), slice(0, 64), slice(0, 64))
-        downsampling_factors = (1, 2, 2, 2)
+        out_slices = (slice(0, 1), slice(0, dest_shape[1]), slice(0, dest_shape[2]), slice(0, dest_shape[3]))
         
         result = downsample_save_chunk_mode(
             source_arr, dest_arr, out_slices,
@@ -128,7 +145,7 @@ def multiscale_result(temp_zarr_array):
     try:
         # Mock wait to return immediately for testing
         with patch('src.to_multiscale.wait', return_value=([], [])):
-            create_multiscale(z_root, dask_client, 'raw', False)
+            create_multiscale(z_root, dask_client, 'raw', False, True)
         
         yield z_root, dask_client, temp_dir
         
@@ -183,19 +200,26 @@ class TestMultiscaleMetadata:
     def test_multiscale_array_shapes(self, multiscale_result):
         """Test that multiscale arrays have correct shapes."""
         z_root, dask_client, temp_dir = multiscale_result
-        
-        # Get the base array shape
-        s0_shape = z_root['s0'].shape
+        axes_order = [axis['name'].lower() for axis in z_root.attrs['multiscales'][0]['axes']]
         
         # Check that each level is downsampled by factor of 2
-        for level in range(1, 4):  # Check s1, s2, s3
+        level = 1
+        spatial_shape = z_root[f's{level-1}'].shape[1:]
+
+        while all([dim > 32 for dim in spatial_shape]):  # Check s1, s2, s3
             level_name = f's{level}'
+            arrprev_shape = z_root[f's{level-1}'].shape
+
+            scaling_factors = get_downsampling_factors(arrprev_shape, axes_order, high_aspect_ratio=True)
             if level_name in z_root:
                 level_array = z_root[level_name]
                 expected_shape = tuple(
-                    dim // (2 ** level) if i > 0 else dim  # Don't downsample channel dimension
-                    for i, dim in enumerate(s0_shape)
+                    dim // sc  # Don't downsample channel dimension
+                    for dim, sc in zip(arrprev_shape,scaling_factors)
                 )
+
+                spatial_shape = level_array.shape[1:]
+                level += 1
                 assert level_array.shape == expected_shape, f"Level {level} has wrong shape"
     
     def test_multiscale_coordinate_transformations(self, multiscale_result):
@@ -204,6 +228,7 @@ class TestMultiscaleMetadata:
         
         multiscales = z_root.attrs['multiscales']
         datasets = multiscales[0]['datasets']
+        axes_order = [axis['name'].lower() for axis in z_root.attrs['multiscales'][0]['axes']]
         
         # Check coordinate transformations for each level
         for i, dataset in enumerate(datasets):
@@ -219,13 +244,28 @@ class TestMultiscaleMetadata:
             # Channel scale should always be 1.0
             assert scale[0] == 1.0
             
-            # Spatial scales should increase by factor of 2 each level
+            # Spatial scales should increase based on actual downsampling factors
             if i > 0:
                 base_scale = datasets[0]['coordinateTransformations'][0]['scale']
-                expected_factor = 2 ** i
-                for dim in [1, 2, 3]:  # z, y, x
-                    expected_scale = base_scale[dim] * expected_factor
-                    assert abs(scale[dim] - expected_scale) < 0.001
+                
+                # Calculate cumulative scaling factors up to this level
+                cumulative_factors = [1.0] * len(axes_order)  # Start with no scaling
+                
+                for level in range(1, i + 1):
+                    # Get the shape of the previous level to calculate downsampling factors
+                    prev_level_path = datasets[level - 1]['path']
+                    if prev_level_path in z_root:
+                        prev_shape = z_root[prev_level_path].shape
+                        level_factors = get_downsampling_factors(prev_shape, axes_order, high_aspect_ratio=True)
+                        
+                        # Apply these factors to cumulative scaling
+                        for dim_idx, factor in enumerate(level_factors):
+                            cumulative_factors[dim_idx] *= factor
+                
+                # Check that the scale matches expected cumulative scaling
+                for dim in [1, 2, 3]:  # z, y, x dimensions
+                    expected_scale = base_scale[dim] * cumulative_factors[dim]
+                    assert abs(scale[dim] - expected_scale) < 0.001, f"Level {i}, dim {dim}: expected {expected_scale}, got {scale[dim]}"
             
             # Check translation transformation
             translation_transform = transforms[1]
@@ -243,15 +283,15 @@ class TestMultiscaleMetadata:
         if 's1' in z_root:
             s1_data = z_root['s1'][:]
             
-            # Data should be in similar range (averaged values)
-            assert s1_data.min() >= 0  # Should be non-negative
-            assert s1_data.max() <= s0_data.max() * 1.1  # Shouldn't exceed original by much
-            assert s1_data.mean() > 0  # Should have meaningful data
+            assert s1_data.min() >= 0  
+            assert s1_data.max() <= s0_data.max() * 1.1 
+            assert s1_data.mean() > 0 
+            assert s1_data.shape[0] == s0_data.shape[0]  
             
-            # Shape should be roughly half in spatial dimensions
-            assert s1_data.shape[0] == s0_data.shape[0]  # Channel unchanged
-            for dim in [1, 2, 3]:  # z, y, x dimensions
-                assert s1_data.shape[dim] <= s0_data.shape[dim] // 2 + 1
+            assert s1_data.std() > 0  
+            
+            mean_ratio = s1_data.mean() / s0_data.mean()
+            assert 0.5 <= mean_ratio <= 2.0, f"Mean ratio {mean_ratio} is outside reasonable range"
     
     def test_multiscale_version_and_format(self, multiscale_result):
         """Test multiscale version and format compliance."""


### PR DESCRIPTION
- Anisotropic downsampling: Added an option to progressively reduce high aspect ratio data with each successive multiscale level, with tests covering anisotropic downsampling cases.
- Custom scaling factors per level: Added CLI and config-file support for specifying custom scale factors for each resolution level, replacing the single global scaling factor.
Config file input: Added a `--config` click option to pass all parameters via a YAML config file.
- Pydantic validation: Introduced pydantic_models.py to validate config file parameters at startup; added pydantic as a project dependency.
- Bug fixes: Fixed scaling factor flag handling; fixed a type error where scaling_factors needed to be cast to tuple for windowed_mode/mean downsampling methods.
- LSF cluster: Added a `--project` option for specifying the LSF billing project when submitting jobs to a cluster.